### PR TITLE
fix (HTML header): Add an attribute to an icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         </a>
         <a class="header-top__phone" href="tel:+74953225448">+7 495 322-54-48</a>
         <a class="header-top__account" href="#">
-          <svg width="21" height="12" viewBox="0 0 21 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg aria-hidden="true" width="21" height="12" viewBox="0 0 21 12" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M10.59 1.41L14.17 5H0V7H14.17L10.58 10.59L12 12L18 6L12 0L10.59 1.41ZM19 0V12H21V0H19Z" fill="#CC9933"/>
           </svg>
           <span>Личный кабинет</span>


### PR DESCRIPTION
Added an aria-hidden=“true” attribute for the
decorative icon so it won't be read by screen
readers